### PR TITLE
docs: fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For a deeper dive, check out the [technical details section](#suave-geth-technic
 ### How do I use SUAVE?
 
 1. **Deploy confidential smart contracts.**
-   Smart contracts on SUAVE follow the same rules as on Ethereum with the added advantage of being able to access additional precompiles during confidential execution. Precompiles are available through the [SUAVE library](#SUAVE-library).
+   Smart contracts on SUAVE follow the same rules as on Ethereum with the added advantage of being able to access additional precompiles during confidential execution. Precompiles are available through the [SUAVE library](#suave-library).
 
 2. **NEW! Request confidential execution using the new confidential computation request.**
    Contracts called using confidential compute requests have access to off-chain data and APIs through SUAVE precompiles. Confidential computation is *not* reproducible on-chain, thus, users are required to whitelist a specific execution node trusted to provide the result. Eventually proofs and trusted enclaves will help to verify the results of execution.


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

:v: just starting to look through stuff and noticed GH doesnt like this capitalized anchor id

original doesnt go to the spot for me (chrome/safari)
https://github.com/flashbots/suave-geth#SUAVE-library

while lowercased works
https://github.com/flashbots/suave-geth#suave-library

congrats on the release!

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
